### PR TITLE
Add GitHub Actions workflow to build and sign APKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Build and Sign Release APK
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build and Sign APK
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Check out the code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Set up JDK
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '17' # Adjust to your project Java version
+
+      # Step 3: Decode and save the keystore file
+      - name: Decode keystore
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 -d > key.jks
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+
+      # Step 4: Build the release APK
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+
+      # Step 5: Sign the release APK
+      - name: Sign APK
+        run: |
+          jarsigner -verbose \
+            -sigalg SHA256withRSA \
+            -digestalg SHA-256 \
+            -keystore key.jks \
+            -storepass ${{ secrets.KEYSTORE_PASSWORD }} \
+            -keypass ${{ secrets.KEY_PASSWORD }} \
+            app/build/outputs/apk/release/app-release-unsigned.apk \
+            ${{ secrets.KEY_ALIAS }}
+
+      # Step 6: Optimize APK with zipalign
+      - name: Optimize APK with zipalign
+        run: |
+          $ANDROID_HOME/build-tools/*/zipalign -v -p 4 \
+            app/build/outputs/apk/release/app-release-unsigned.apk \
+            app/build/outputs/apk/release/app-release.apk
+
+      # Step 7: Upload the signed APK as an artifact
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-release.apk
+          path: app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
Set up a CI workflow triggered on release events to automate the process of building, signing, and optimizing Android APKs.

- Check out repository code with `actions/checkout`.
- Configure JDK 17 using `actions/setup-java`.
- Decode keystore from a base64-encoded secret for signing.
- Build release APK via Gradle and sign it using `jarsigner`.
- Optimize the APK using `zipalign`.
- Upload the signed and optimized APK as a workflow artifact.