### PR TITLE
Update upload-artifact action to version 4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Step 7: Upload the signed APK as an artifact
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-release.apk
           path: app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
- Updated the `actions/upload-artifact` action from v3 to v4 in the release workflow.
- Ensures support for the latest features, bug fixes, and security improvements in the GitHub action.