### PR TITLE
Update zipalign path to use specific build-tools version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       # Step 7: Optimize APK with zipalign
       - name: Optimize APK with zipalign
         run: |
-          $ANDROID_HOME/build-tools/*/zipalign -v -p 4 \
+          $ANDROID_HOME/build-tools/35.0.0/zipalign -v -p 4 \
             app/build/outputs/apk/release/app-release-unsigned.apk \
             app/build/outputs/apk/release/app-release.apk
 


### PR DESCRIPTION
### Description

This pull request updates the `zipalign` command to explicitly use build-tools version `35.0.0`. The change eliminates reliance on wildcard versions, ensuring compatibility and preventing potential build errors associated with mismatched tool versions.
