### PR TITLE
Change APK upload to GitHub release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,11 @@ jobs:
             app/build/outputs/apk/release/app-release-unsigned.apk \
             app/build/outputs/apk/release/app-release.apk
 
-      # Step 8: Upload the signed APK as an artifact
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+      # Step 8: Upload the signed APK to GitHub release
+      - name: Upload APK to release
+        uses: actions/upload-release-asset@v1
         with:
-          name: app-release.apk
-          path: app/build/outputs/apk/release/app-release.apk
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: app/build/outputs/apk/release/app-release.apk
+          asset_name: app-release.apk
+          asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
Replaced artifact upload with uploading the signed APK directly to the GitHub release assets. This aligns with better release management practices.

- Updated workflow to use `actions/upload-release-asset@v1`.
- Added parameters for upload URL, asset path, name, and MIME type.