### PR TITLE
Switch to softprops/action-gh-release for APK uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,8 @@ jobs:
 
       # Step 8: Upload the signed APK to GitHub release
       - name: Upload APK to release
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: app/build/outputs/apk/release/app-release.apk
-          asset_name: app-release.apk
-          asset_content_type: application/vnd.android.package-archive
+          files: app/build/outputs/apk/release/app-release.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaced actions/upload-release-asset with softprops/action-gh-release for uploading APKs in the release workflow. This change simplifies the upload configuration and leverages built-in environment management.

- Updated `uses` to softprops/action-gh-release@v1.
- Replaced `with` parameters to use `files` for specifying APK path.
- Added `GITHUB_TOKEN` under `env` for authentication.